### PR TITLE
Adding Activators and Updating Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,5 +133,28 @@ variants: {
 }
 ```
 
+
+## Customizing an Activator Class
+Specifying an activator in the constructor. The default empty. If you plan to not use an activator skip over this section.
+```js
+module.exports = {
+  // ...
+
+  plugins: [
+    // ...
+    require('tailwindcss-prefers-dark-mode')('dark', 'dark')
+  ]
+};
+```
+
+Specifying an activator will require that these generated classes have the activator class on the `HTML` or `body` or `parent` tag. The presence of the dark class on the body will make the dark classes active. Allowing for you to easily switch between a light and dark theme. 
+
+```html
+<body class="dark"> 
+  <div class="bg-gray-100 text-black dark:bg-gray-900 dark:text-white">I'm a little teapot</div>
+</body>
+```
+
+
 [1]: https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js
 [2]: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const postcss = require('postcss');
 
-module.exports = function(prefix = 'dark') {
+module.exports = function(prefix = 'dark', activator = null) {
   return function({ addVariant, e }) {
     addVariant(prefix, ({ container, separator }) => {
       const variant = '';
@@ -80,6 +80,9 @@ module.exports = function(prefix = 'dark') {
           default:
             rule.selector = `.${e(`${prefix}${separator}${rule.selector.slice(1)}`)}`;
             break;
+        }
+        if(activator !== null){
+          rule.selector = `.${activator} ${rule.selector}`;
         }
       });
     }


### PR DESCRIPTION
This adds the ability to customize the activator class on the body. By default it is 'dark-mode' , but some people may like the option to change this.

First Param is the prefix to `dark:mode` or whatever you want it to be. `cats:hover`
Second Param is the activator on the `html` or `body` tag. `dark-mode` or to stick with my above example `cats`

**Default**
`require(tailwindcss-darkmode)('dark', 'dark-mode')`
**Custom**
`require(tailwindcss-darkmode)('dark', 'cats')`